### PR TITLE
12-chess-notation-adapter

### DIFF
--- a/src/logic/ChessNotationAdapter.ts
+++ b/src/logic/ChessNotationAdapter.ts
@@ -1,9 +1,10 @@
 import Board from "./Board"
 import Position from "./Position"
+import Piece from "./Piece"
 
-const xToChinese = ["一", "二", "三", "四", "五", "六", "七", "八", "九"]
 const RED_START_X = 8
 const BLACK_START_X = 0
+const xToChinese = ["一", "二", "三", "四", "五", "六", "七", "八", "九"]
 
 const PieceNameMap: Record<number, [string, string]> = {
   0: ["仕", "士"], // Advisor
@@ -15,40 +16,64 @@ const PieceNameMap: Record<number, [string, string]> = {
   6: ["兵", "卒"] // Pawn
 }
 
-/** Returns the Chinese character name for a given piece code */
 export function getPieceName(code: number): string {
-  const isRed = code < 10
   const baseCode = code % 10
-  const names = PieceNameMap[baseCode]
-  return isRed ? names[0] : names[1]
+  const isRed = code < 10
+  return isRed ? PieceNameMap[baseCode][0] : PieceNameMap[baseCode][1]
+}
+
+function getPawnPrefix(board: Board, piece: Piece): string {
+  const isRed = piece.getCode() < 10
+  const x = piece.getPosition().getX()
+
+  const allPieces = Array.from(board.getPieces())
+
+  const sameColumnPawns = allPieces.filter(
+    (p) => p.getCode() === piece.getCode() && p.getPosition().getX() === x
+  )
+
+  if (sameColumnPawns.length >= 3) {
+    const sorted = sameColumnPawns.sort((a, b) => {
+      const ya = a.getPosition().getY()
+      const yb = b.getPosition().getY()
+      return isRed ? yb - ya : ya - yb
+    })
+    const index = sorted.findIndex((p) => p === piece)
+    return xToChinese[index]
+  }
+
+  return ""
 }
 
 export default class ChessNotationAdapter {
   public static toNotation(board: Board, from: Position, to: Position): string {
     const allPieces = Array.from(board.getPieces())
-    const movingPiece = allPieces.find((p) => p.getPosition().equals(from))
-    if (!movingPiece) throw new Error("No piece at source position")
+    const piece = allPieces.find((p) => p.getPosition().equals(from))
+    if (!piece) throw new Error("No piece at source position")
 
-    const code = movingPiece.getCode()
-    const isRed = code < 10
-    const pieceName = getPieceName(code)
+    const isRed = piece.getCode() < 10
+    const baseCode = piece.getCode() % 10
+    const pieceName = getPieceName(piece.getCode())
 
-    // Handle front/back (前/后) disambiguation
-    const sameColumn = allPieces.filter(
+    const sameColumnSameType = allPieces.filter(
       (p) =>
-        p !== movingPiece &&
-        p.getCode() === code &&
+        p !== piece &&
+        p.getCode() === piece.getCode() &&
         p.getPosition().getX() === from.getX()
     )
 
     let prefix = ""
-    if (sameColumn.length > 0) {
-      const ordered = sameColumn.concat([movingPiece]).sort((a, b) => {
+    if (baseCode === 6) {
+      prefix = getPawnPrefix(board, piece)
+    }
+
+    if (!prefix && sameColumnSameType.length > 0) {
+      const sorted = sameColumnSameType.concat([piece]).sort((a, b) => {
         return isRed
           ? b.getPosition().getY() - a.getPosition().getY()
           : a.getPosition().getY() - b.getPosition().getY()
       })
-      const index = ordered.findIndex((p) => p === movingPiece)
+      const index = sorted.findIndex((p) => p === piece)
       prefix = index === 0 ? "前" : "后"
     }
 
@@ -74,20 +99,22 @@ export default class ChessNotationAdapter {
         : xToChinese[BLACK_START_X + toX]
     } else if ((isRed && toY > fromY) || (!isRed && toY < fromY)) {
       action = "进"
-      dest =
-        fromX === toX
-          ? xToChinese[Math.abs(toY - fromY) - 1]
-          : isRed
-            ? xToChinese[RED_START_X - toX]
-            : xToChinese[BLACK_START_X + toX]
+      if (fromX === toX) {
+        dest = xToChinese[Math.abs(toY - fromY) - 1]
+      } else {
+        dest = isRed
+          ? xToChinese[RED_START_X - toX]
+          : xToChinese[BLACK_START_X + toX]
+      }
     } else {
       action = "退"
-      dest =
-        fromX === toX
-          ? xToChinese[Math.abs(fromY - toY) - 1]
-          : isRed
-            ? xToChinese[RED_START_X - toX]
-            : xToChinese[BLACK_START_X + toX]
+      if (fromX === toX) {
+        dest = xToChinese[Math.abs(fromY - toY) - 1]
+      } else {
+        dest = isRed
+          ? xToChinese[RED_START_X - toX]
+          : xToChinese[BLACK_START_X + toX]
+      }
     }
 
     return `${prefix}${pieceName}${file}${action}${dest}`

--- a/src/logic/ChessNotationAdapter.ts
+++ b/src/logic/ChessNotationAdapter.ts
@@ -1,29 +1,30 @@
 import Board from "./Board"
 import Position from "./Position"
 import Piece from "./Piece"
+import PieceCode from "./factory/PieceCode"
 
 const RED_START_X = 8
 const BLACK_START_X = 0
 const xToChinese = ["一", "二", "三", "四", "五", "六", "七", "八", "九"]
 
-const PieceNameMap: Record<number, [string, string]> = {
-  0: ["仕", "士"], // Advisor
-  1: ["相", "象"], // Elephant
-  2: ["帥", "將"], // General
-  3: ["馬", "傌"], // Horse
-  4: ["車", "俥"], // Rook
-  5: ["炮", "砲"], // Cannon
-  6: ["兵", "卒"] // Pawn
+const PieceNameMap: Record<PieceCode, [string, string]> = {
+  [PieceCode.ADVISOR]: ["仕", "士"], // Advisor
+  [PieceCode.ELEPHANT]: ["相", "象"], // Elephant
+  [PieceCode.GENERAL]: ["帥", "將"], // General
+  [PieceCode.HORSE]: ["馬", "傌"], // Horse
+  [PieceCode.ROOK]: ["車", "俥"], // Rook
+  [PieceCode.CANNON]: ["炮", "砲"], // Cannon
+  [PieceCode.PAWN]: ["兵", "卒"] // Pawn
 }
 
-export function getPieceName(code: number): string {
-  const baseCode = code % 10
-  const isRed = code < 10
-  return isRed ? PieceNameMap[baseCode][0] : PieceNameMap[baseCode][1]
+export function getPieceName(piece: Piece): string {
+  const code = piece.getCode()
+  const isRed = piece.isRed()
+  return isRed ? PieceNameMap[code][0] : PieceNameMap[code][1]
 }
 
 function getPawnPrefix(board: Board, piece: Piece): string {
-  const isRed = piece.getCode() < 10
+  const isRed = piece.isRed()
   const x = piece.getPosition().getX()
 
   const allPieces = Array.from(board.getPieces())
@@ -51,9 +52,8 @@ export default class ChessNotationAdapter {
     const piece = allPieces.find((p) => p.getPosition().equals(from))
     if (!piece) throw new Error("No piece at source position")
 
-    const isRed = piece.getCode() < 10
-    const baseCode = piece.getCode() % 10
-    const pieceName = getPieceName(piece.getCode())
+    const isRed = piece.isRed()
+    const pieceName = getPieceName(piece)
 
     const sameColumnSameType = allPieces.filter(
       (p) =>
@@ -63,7 +63,7 @@ export default class ChessNotationAdapter {
     )
 
     let prefix = ""
-    if (baseCode === 6) {
+    if (piece.getCode() === PieceCode.PAWN) {
       prefix = getPawnPrefix(board, piece)
     }
 

--- a/src/logic/ChessNotationAdapter.ts
+++ b/src/logic/ChessNotationAdapter.ts
@@ -1,0 +1,95 @@
+import Board from "./Board"
+import Position from "./Position"
+
+const xToChinese = ["一", "二", "三", "四", "五", "六", "七", "八", "九"]
+const RED_START_X = 8
+const BLACK_START_X = 0
+
+const PieceNameMap: Record<number, [string, string]> = {
+  0: ["仕", "士"], // Advisor
+  1: ["相", "象"], // Elephant
+  2: ["帥", "將"], // General
+  3: ["馬", "傌"], // Horse
+  4: ["車", "俥"], // Rook
+  5: ["炮", "砲"], // Cannon
+  6: ["兵", "卒"] // Pawn
+}
+
+/** Returns the Chinese character name for a given piece code */
+export function getPieceName(code: number): string {
+  const isRed = code < 10
+  const baseCode = code % 10
+  const names = PieceNameMap[baseCode]
+  return isRed ? names[0] : names[1]
+}
+
+export default class ChessNotationAdapter {
+  public static toNotation(board: Board, from: Position, to: Position): string {
+    const allPieces = Array.from(board.getPieces())
+    const movingPiece = allPieces.find((p) => p.getPosition().equals(from))
+    if (!movingPiece) throw new Error("No piece at source position")
+
+    const code = movingPiece.getCode()
+    const isRed = code < 10
+    const pieceName = getPieceName(code)
+
+    // Handle front/back (前/后) disambiguation
+    const sameColumn = allPieces.filter(
+      (p) =>
+        p !== movingPiece &&
+        p.getCode() === code &&
+        p.getPosition().getX() === from.getX()
+    )
+
+    let prefix = ""
+    if (sameColumn.length > 0) {
+      const ordered = sameColumn.concat([movingPiece]).sort((a, b) => {
+        return isRed
+          ? b.getPosition().getY() - a.getPosition().getY()
+          : a.getPosition().getY() - b.getPosition().getY()
+      })
+      const index = ordered.findIndex((p) => p === movingPiece)
+      prefix = index === 0 ? "前" : "后"
+    }
+
+    const fromX = from.getX()
+    const toX = to.getX()
+    const fromY = from.getY()
+    const toY = to.getY()
+
+    let file = ""
+    if (!prefix) {
+      file = isRed
+        ? xToChinese[RED_START_X - fromX]
+        : xToChinese[BLACK_START_X + fromX]
+    }
+
+    let action: string
+    let dest: string
+
+    if (fromY === toY) {
+      action = "平"
+      dest = isRed
+        ? xToChinese[RED_START_X - toX]
+        : xToChinese[BLACK_START_X + toX]
+    } else if ((isRed && toY > fromY) || (!isRed && toY < fromY)) {
+      action = "进"
+      dest =
+        fromX === toX
+          ? xToChinese[Math.abs(toY - fromY) - 1]
+          : isRed
+            ? xToChinese[RED_START_X - toX]
+            : xToChinese[BLACK_START_X + toX]
+    } else {
+      action = "退"
+      dest =
+        fromX === toX
+          ? xToChinese[Math.abs(fromY - toY) - 1]
+          : isRed
+            ? xToChinese[RED_START_X - toX]
+            : xToChinese[BLACK_START_X + toX]
+    }
+
+    return `${prefix}${pieceName}${file}${action}${dest}`
+  }
+}

--- a/tests/src/logic/ChessNotationAdapter.test.ts
+++ b/tests/src/logic/ChessNotationAdapter.test.ts
@@ -202,4 +202,46 @@ describe("ChessNotationAdapter - toNotation", () => {
     )
     expect(notation).toBe("后炮退一")
   })
+
+  //mutiple chess
+
+  test("Three red Pawns in same column, the third one moves back => 三兵退一", () => {
+    const first = createPawnStub(true, new Position(8, 7))
+    const second = createPawnStub(true, new Position(8, 5))
+    const third = createPawnStub(true, new Position(8, 3))
+    const board = new Board([first, second, third])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 3),
+      new Position(8, 2)
+    )
+    expect(notation).toBe("三兵退一")
+  })
+
+  test("Three red Pawns in same column, the second one moves horizontally => 二兵平二", () => {
+    const first = createPawnStub(true, new Position(8, 7))
+    const second = createPawnStub(true, new Position(8, 5))
+    const third = createPawnStub(true, new Position(8, 3))
+    const board = new Board([first, second, third])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 5),
+      new Position(7, 5)
+    )
+    expect(notation).toBe("二兵平二")
+  })
+
+  test("Four red Pawns in same column, the second one moves horizontally => 四兵退一", () => {
+    const first = createPawnStub(true, new Position(8, 7))
+    const second = createPawnStub(true, new Position(8, 5))
+    const third = createPawnStub(true, new Position(8, 3))
+    const fourth = createPawnStub(true, new Position(8, 2))
+    const board = new Board([first, second, third, fourth])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 2),
+      new Position(8, 1)
+    )
+    expect(notation).toBe("四兵退一")
+  })
 })

--- a/tests/src/logic/ChessNotationAdapter.test.ts
+++ b/tests/src/logic/ChessNotationAdapter.test.ts
@@ -4,10 +4,11 @@ import ChessNotationAdapter, {
 import Board from "../../../src/logic/Board"
 import Position from "../../../src/logic/Position"
 import Piece from "../../../src/logic/Piece"
+import PieceCode from "../../../src/logic/factory/PieceCode"
 
 class PieceStub extends Piece {
-  constructor(code: number, position: Position) {
-    super(code, position)
+  constructor(code: PieceCode, isRed: boolean, position: Position) {
+    super(code, isRed, position)
   }
 
   getAllValidMoves(): Position[] {
@@ -15,44 +16,36 @@ class PieceStub extends Piece {
   }
 
   toString(): string {
-    return getPieceName(this.getCode())
+    return getPieceName(this)
   }
 }
 
-function createStub(
-  code: number,
-  isRed: boolean,
-  position: Position
-): PieceStub {
-  return new PieceStub(isRed ? code : code + 10, position)
-}
-
 function createHorseStub(isRed: boolean, position: Position) {
-  return createStub(3, isRed, position)
+  return new PieceStub(PieceCode.HORSE, isRed, position)
 }
 
 function createElephantStub(isRed: boolean, position: Position) {
-  return createStub(1, isRed, position)
+  return new PieceStub(PieceCode.ELEPHANT, isRed, position)
 }
 
 function createAdvisorStub(isRed: boolean, position: Position) {
-  return createStub(0, isRed, position)
+  return new PieceStub(PieceCode.ADVISOR, isRed, position)
 }
 
 function createRookStub(isRed: boolean, position: Position) {
-  return createStub(4, isRed, position)
+  return new PieceStub(PieceCode.ROOK, isRed, position)
 }
 
 function createCannonStub(isRed: boolean, position: Position) {
-  return createStub(5, isRed, position)
+  return new PieceStub(PieceCode.CANNON, isRed, position)
 }
 
 function createPawnStub(isRed: boolean, position: Position) {
-  return createStub(6, isRed, position)
+  return new PieceStub(PieceCode.PAWN, isRed, position)
 }
 
 function createGeneralStub(isRed: boolean, position: Position) {
-  return createStub(2, isRed, position)
+  return new PieceStub(PieceCode.GENERAL, isRed, position)
 }
 
 describe("ChessNotationAdapter - toNotation", () => {

--- a/tests/src/logic/ChessNotationAdapter.test.ts
+++ b/tests/src/logic/ChessNotationAdapter.test.ts
@@ -1,0 +1,205 @@
+import ChessNotationAdapter, {
+  getPieceName
+} from "../../../src/logic/ChessNotationAdapter"
+import Board from "../../../src/logic/Board"
+import Position from "../../../src/logic/Position"
+import Piece from "../../../src/logic/Piece"
+
+class PieceStub extends Piece {
+  constructor(code: number, position: Position) {
+    super(code, position)
+  }
+
+  getAllValidMoves(): Position[] {
+    return []
+  }
+
+  toString(): string {
+    return getPieceName(this.getCode())
+  }
+}
+
+function createStub(
+  code: number,
+  isRed: boolean,
+  position: Position
+): PieceStub {
+  return new PieceStub(isRed ? code : code + 10, position)
+}
+
+function createHorseStub(isRed: boolean, position: Position) {
+  return createStub(3, isRed, position)
+}
+
+function createElephantStub(isRed: boolean, position: Position) {
+  return createStub(1, isRed, position)
+}
+
+function createAdvisorStub(isRed: boolean, position: Position) {
+  return createStub(0, isRed, position)
+}
+
+function createRookStub(isRed: boolean, position: Position) {
+  return createStub(4, isRed, position)
+}
+
+function createCannonStub(isRed: boolean, position: Position) {
+  return createStub(5, isRed, position)
+}
+
+function createPawnStub(isRed: boolean, position: Position) {
+  return createStub(6, isRed, position)
+}
+
+function createGeneralStub(isRed: boolean, position: Position) {
+  return createStub(2, isRed, position)
+}
+
+describe("ChessNotationAdapter - toNotation", () => {
+  test("Red Horse from (1, 0) to (2, 2) => 馬八进七", () => {
+    const horse = createHorseStub(true, new Position(1, 0))
+    const board = new Board([horse])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(1, 0),
+      new Position(2, 2)
+    )
+    expect(notation).toBe("馬八进七")
+  })
+
+  test("Red Horse from (7, 9) to (6, 7) => 馬二退三", () => {
+    const horse = createHorseStub(true, new Position(7, 9))
+    const board = new Board([horse])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(7, 9),
+      new Position(6, 7)
+    )
+    expect(notation).toBe("馬二退三")
+  })
+
+  test("Black Horse from (7, 9) to (6, 7) => 傌八进七", () => {
+    const horse = createHorseStub(false, new Position(7, 9))
+    const board = new Board([horse])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(7, 9),
+      new Position(6, 7)
+    )
+    expect(notation).toBe("傌八进七")
+  })
+
+  test("Red Elephant from (6, 0) to (4, 2) => 相三进五", () => {
+    const elephant = createElephantStub(true, new Position(6, 0))
+    const board = new Board([elephant])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(6, 0),
+      new Position(4, 2)
+    )
+    expect(notation).toBe("相三进五")
+  })
+
+  test("Red Advisor from (5, 0) to (4, 1) => 仕四进五", () => {
+    const advisor = createAdvisorStub(true, new Position(5, 0))
+    const board = new Board([advisor])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(5, 0),
+      new Position(4, 1)
+    )
+    expect(notation).toBe("仕四进五")
+  })
+
+  test("Red Rook from (7, 9) to (6, 9) => 車二平三", () => {
+    const rook = createRookStub(true, new Position(7, 9))
+    const board = new Board([rook])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(7, 9),
+      new Position(6, 9)
+    )
+    expect(notation).toBe("車二平三")
+  })
+
+  test("Red Rook from (7, 1) to (7, 4) => 車二进三", () => {
+    const rook = createRookStub(true, new Position(7, 1))
+    const board = new Board([rook])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(7, 1),
+      new Position(7, 4)
+    )
+    expect(notation).toBe("車二进三")
+  })
+
+  test("Red Rook from (7, 7) to (7, 4) => 車二退三", () => {
+    const rook = createRookStub(true, new Position(7, 7))
+    const board = new Board([rook])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(7, 7),
+      new Position(7, 4)
+    )
+    expect(notation).toBe("車二退三")
+  })
+
+  test("Red Pawn from (8, 3) to (8, 4) => 兵一进一", () => {
+    const pawn = createPawnStub(true, new Position(8, 3))
+    const board = new Board([pawn])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 3),
+      new Position(8, 4)
+    )
+    expect(notation).toBe("兵一进一")
+  })
+
+  test("Red Pawn from (8, 5) to (7, 5) => 兵一平二", () => {
+    const pawn = createPawnStub(true, new Position(8, 5))
+    const board = new Board([pawn])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 5),
+      new Position(7, 5)
+    )
+    expect(notation).toBe("兵一平二")
+  })
+
+  test("Black General from (4, 9) to (4, 8) => 將五进一", () => {
+    const general = createGeneralStub(false, new Position(4, 9))
+    const board = new Board([general])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(4, 9),
+      new Position(4, 8)
+    )
+    expect(notation).toBe("將五进一")
+  })
+
+  //double chess
+
+  test("Two red Rooks in same column, front one moves forward => 前車进二", () => {
+    const front = createRookStub(true, new Position(0, 5))
+    const back = createRookStub(true, new Position(0, 2))
+    const board = new Board([front, back])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(0, 5),
+      new Position(0, 7)
+    )
+    expect(notation).toBe("前車进二")
+  })
+
+  test("Two red Cannons in same column, back one moves back => 后炮退一", () => {
+    const front = createCannonStub(true, new Position(8, 9))
+    const back = createCannonStub(true, new Position(8, 7))
+    const board = new Board([front, back])
+    const notation = ChessNotationAdapter.toNotation(
+      board,
+      new Position(8, 7),
+      new Position(8, 6)
+    )
+    expect(notation).toBe("后炮退一")
+  })
+})


### PR DESCRIPTION
Add ChessNotationAdapter to convert movement of target piece into Chinese chess notation.
1. Analyze the current status of the checkerboard, including the current and destination positions of the target piece.
2. Provide logic to convert movement direction into Chinese notation using "进", "退", and "平", depending on the piece’s orientation and movement.
3. Convert movement details into Chinese numerals for notation:
- For Horse, Elephant, and Advisor: The first number represents the current file (x-coordinate), and the second number represents the destination file (x-coordinate).
- For all other pieces: The first number represents the current file (x-coordinate), and the second number represents the number of ranks moved vertically (y-distance).
4. Convert the piece type and color into corresponding Chinese character names, using a mapping based on the piece's code.
5. Handle special notation cases:
- For identical pieces in the same column, add prefixes like "前" and "后" based on relative position.
- For Pawns, when three or more are in the same column, assign numeric prefixes like "一", "二", "三" according to proximity to the enemy side (closer = smaller number).